### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(boost_contract
     Boost::optional
     Boost::preprocessor
     Boost::smart_ptr
-    Boost::static_assert
     Boost::thread
     Boost::type_traits
     Boost::typeof

--- a/build.jam
+++ b/build.jam
@@ -17,7 +17,6 @@ constant boost_dependencies :
     /boost/optional//boost_optional
     /boost/preprocessor//boost_preprocessor
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/thread//boost_thread
     /boost/type_traits//boost_type_traits
     /boost/typeof//boost_typeof


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.